### PR TITLE
Adds base_url to options object to support different construct instances

### DIFF
--- a/lib/rest-client.js
+++ b/lib/rest-client.js
@@ -7,6 +7,13 @@ var _config = null;
 
 exports.setup = function (config) {
     _config = config;
+    if(_config !== null){
+        if(config.base_url !== null && typeof config.base_url !== "undefined"){
+            API_ENDPOINT = `${config.base_url}`;
+            AUTH_ENDPOINT = `${config.base_url}/oauth2/token`;
+            TOKEN_ENDPOINT = `${config.base_url}/oauth2/tokeninfo`;
+        }
+    }
 }
 
 exports.get = function (path, params, auth_type, callback) {


### PR DESCRIPTION
Add support for providing a different base url so tests can use construct dev, ANZ can use Australia construct, etc.